### PR TITLE
v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+# v0.1.9 - 2024-07-30
+
+- Removed `create_shifted_mask` as `create_mask() << 5` is a trivial replacement
+- Renamed `toggle` to `toggle_bit`
+- Added `toggle_bits`
+
 # v0.1.8 - 2024-07-15
 
 - Added `get_bit` function that is like `is_set` but returns an integer instead

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ Common bit-oriented operations on primitive integer types with a focus on
 create sophisticated high-level types with bitfields, the focus of `bit_ops` is
 on raw primitive integer types.
 """
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 authors = [
   "Philipp Schuster <phip1611@gmail.com>"

--- a/README.md
+++ b/README.md
@@ -56,4 +56,9 @@ fn main() {
 
 ## MSRV
 
+<!-- Keep in sync with lib.rs and Cargo.toml!  -->
 1.57.0 stable
+
+## License
+
+MIT License. See [LICENSE](./LICENSE) file.

--- a/src/function_api/macros.rs
+++ b/src/function_api/macros.rs
@@ -135,7 +135,7 @@ macro_rules! impl_bit_ops {
         /// the underlying type.
         #[must_use]
         #[inline]
-        pub const fn get_bit(val: $primitive_ty, bit: $primitive_ty) -> $primitive_ty  {
+        pub const fn get_bit(val: $primitive_ty, bit: $primitive_ty) -> $primitive_ty {
             assert_in_range(bit, false);
             (val >> bit) & 1
         }
@@ -193,7 +193,7 @@ macro_rules! impl_bit_ops {
         pub const fn toggle_bits(
             value: $primitive_ty,
             bits: $primitive_ty,
-            shift: $primitive_ty
+            shift: $primitive_ty,
         ) -> $primitive_ty {
             assert_in_range(bits, true);
             assert_in_range(shift, true);
@@ -292,7 +292,11 @@ macro_rules! impl_bit_ops {
         // TODO make const as soon as for-loops can be in const fn
         pub fn set_bits_n(
             base: $primitive_ty,
-            ops: &[($primitive_ty /* value */, $primitive_ty /* value_bits */, $primitive_ty /* value_shift */)],
+            ops: &[(
+                $primitive_ty, /* value */
+                $primitive_ty, /* value_bits */
+                $primitive_ty, /* value_shift */
+            )],
         ) -> $primitive_ty {
             let mut base = base;
             for op in ops {
@@ -325,7 +329,11 @@ macro_rules! impl_bit_ops {
         // TODO make const as soon as for-loops can be in const fn
         pub fn set_bits_exact_n(
             base: $primitive_ty,
-            ops: &[($primitive_ty /* value */, $primitive_ty /* value_bits */, $primitive_ty /* value_shift */)],
+            ops: &[(
+                $primitive_ty, /* value */
+                $primitive_ty, /* value_bits */
+                $primitive_ty, /* value_shift */
+            )],
         ) -> $primitive_ty {
             let mut base = base;
             for op in ops {
@@ -421,12 +429,11 @@ macro_rules! impl_bit_ops {
         pub const fn get_bits(
             base: $primitive_ty,
             value_bits: $primitive_ty,
-            value_shift: $primitive_ty
+            value_shift: $primitive_ty,
         ) -> $primitive_ty {
             let mask = create_mask(value_bits);
             (base >> value_shift) & mask
         }
-
 
         /// Creates a bitmask (`1`s) with the given amount of contiguous bits.
         ///
@@ -452,8 +459,7 @@ macro_rules! impl_bit_ops {
                 0
             } else if bits == BIT_COUNT {
                 <$primitive_ty>::MAX
-            }
-            else {
+            } else {
                 paste::paste! {
                     [< 1_ $primitive_ty >].wrapping_shl(bits as u32) - 1
                 }

--- a/src/function_api/macros.rs
+++ b/src/function_api/macros.rs
@@ -147,12 +147,12 @@ macro_rules! impl_bit_ops {
         /// # Example
         ///
         /// ```rust
-        #[doc = concat!("use bit_ops::bitops_", stringify!($primitive_ty), "::toggle;")]
+        #[doc = concat!("use bit_ops::bitops_", stringify!($primitive_ty), "::toggle_bit;")]
         ///
-        /// assert_eq!(toggle(0, 0), 1);
-        /// assert_eq!(toggle(0, 1), 2);
-        /// assert_eq!(toggle(0, 2), 4);
-        /// assert_eq!(toggle(0, 7), 128);
+        /// assert_eq!(toggle_bit(0, 0), 1);
+        /// assert_eq!(toggle_bit(0, 1), 2);
+        /// assert_eq!(toggle_bit(0, 2), 4);
+        /// assert_eq!(toggle_bit(0, 7), 128);
         /// ```
         ///
         /// # Panics
@@ -160,23 +160,56 @@ macro_rules! impl_bit_ops {
         /// the underlying type.
         #[must_use]
         #[inline]
-        pub const fn toggle(val: $primitive_ty, bit: $primitive_ty) -> $primitive_ty {
-            assert_in_range(bit, false);
-            if is_set(val, bit) {
-                clear_bit(val, bit)
-            } else {
-                set_bit(val, bit)
-            }
+        pub const fn toggle_bit(val: $primitive_ty, bit: $primitive_ty) -> $primitive_ty {
+            toggle_bits(val, 1, bit)
         }
 
-        /// Sets the bits of `value` in `base` without clearing already set bits.
+        /// Toggles (flips) the specified contiguous bits.
+        ///
+        /// # Parameters
+        ///
+        /// - `value`: Base value to alter.
+        /// - `bits`: Amount of bits of `value` that are relevant, starting from the right.
+        /// - `shift`: Relevant position of bits inside `value`, starting from the right.
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        #[doc = concat!("use bit_ops::bitops_", stringify!($primitive_ty), "::toggle_bits;")]
+        ///
+        /// assert_eq!(toggle_bits(0, 1, 0), 1);
+        /// assert_eq!(toggle_bits(0, 1, 1), 2);
+        /// assert_eq!(toggle_bits(0, 1, 2), 4);
+        /// assert_eq!(toggle_bits(0, 1, 7), 128);
+        /// assert_eq!(toggle_bits(1, 2, 1), 0b111);
+        /// assert_eq!(toggle_bits(0b1000_0100, 4, 2), 0b1011_1000);
+        /// ```
+        ///
+        /// # Panics
+        /// This function panics for overflowing shifts and bit positions that
+        /// are outside the range of the underlying type.
+        #[must_use]
+        #[inline]
+        pub const fn toggle_bits(
+            value: $primitive_ty,
+            bits: $primitive_ty,
+            shift: $primitive_ty
+        ) -> $primitive_ty {
+            assert_in_range(bits, true);
+            assert_in_range(shift, true);
+            let mask = create_mask(bits) << shift;
+            value ^ mask
+        }
+
+        /// Sets the bits of `value` in `base` without clearing already set
+        /// bits.
         ///
         /// # Parameters
         ///
         /// - `base`: Base value to set bits in.
         /// - `value`: New value/bits to be set in `base`, but unshifted.
         /// - `value_bits`: Amount of bits of `value` that are relevant, starting from the right.
-        /// - `value_shit`: Position of `value` inside `base`.
+        /// - `value_shit`: Position of `value` inside `base`, starting from the right.
         ///
         /// # Example
         ///
@@ -289,6 +322,7 @@ macro_rules! impl_bit_ops {
         /// inner loop.
         #[must_use]
         #[inline]
+        // TODO make const as soon as for-loops can be in const fn
         pub fn set_bits_exact_n(
             base: $primitive_ty,
             ops: &[($primitive_ty /* value */, $primitive_ty /* value_bits */, $primitive_ty /* value_shift */)],
@@ -339,7 +373,8 @@ macro_rules! impl_bit_ops {
             if val == 0 {
                 None
             } else {
-                let bit = BIT_COUNT - (val.leading_zeros() as $primitive_ty) - 1;
+                let max_pos = BIT_COUNT - 1;
+                let bit = max_pos - (val.leading_zeros() as $primitive_ty);
                 Some(bit)
             }
         }
@@ -368,7 +403,7 @@ macro_rules! impl_bit_ops {
             }
         }
 
-        /// Get the requested bits as new integer.
+        /// Get the requested contiguous bits as new integer.
         ///
         /// # Parameters
         ///
@@ -393,7 +428,7 @@ macro_rules! impl_bit_ops {
         }
 
 
-        /// Creates a bitmask (`1`s) with the given amount of bits.
+        /// Creates a bitmask (`1`s) with the given amount of contiguous bits.
         ///
         /// # Example
         ///
@@ -423,32 +458,6 @@ macro_rules! impl_bit_ops {
                     [< 1_ $primitive_ty >].wrapping_shl(bits as u32) - 1
                 }
             }
-        }
-
-        /// Like [`create_mask`] but shifts the mask.
-        ///
-        /// # Example
-        ///
-        /// ```rust
-        #[doc = concat!("use bit_ops::bitops_", stringify!($primitive_ty), "::create_shifted_mask;")]
-        ///
-        /// assert_eq!(create_shifted_mask(0, 3), 0);
-        /// assert_eq!(create_shifted_mask(1, 3), 0b1000);
-        /// assert_eq!(create_shifted_mask(3, 2), 0b11100);
-        /// ```
-        ///
-        /// # Panics
-        ///
-        /// This function panics for overflowing shifts and bit positions that
-        /// are outside the range of the underlying type.
-        #[must_use]
-        #[inline]
-        pub const fn create_shifted_mask(
-            bits: $primitive_ty,
-            lshift: $primitive_ty,
-        ) -> $primitive_ty {
-            assert_in_range(bits, true);
-            create_mask(bits) << lshift
         }
     };
 }

--- a/src/function_api/mod.rs
+++ b/src/function_api/mod.rs
@@ -110,16 +110,29 @@ mod tests {
     }
 
     #[test]
-    fn toggle() {
-        assert!(bitops_u8::is_set(bitops_u8::toggle(0, 0), 0));
-        assert!(!bitops_u8::is_set(bitops_u8::toggle(1, 0), 0));
-        assert_eq!(bitops_u8::toggle(3, 0), 0b10);
-        assert_eq!(bitops_u8::toggle(u8::MAX, 7), u8::MAX / 2);
+    fn toggle_bit() {
+        assert!(bitops_u8::is_set(bitops_u8::toggle_bit(0, 0), 0));
+        assert!(!bitops_u8::is_set(bitops_u8::toggle_bit(1, 0), 0));
+        assert_eq!(bitops_u8::toggle_bit(3, 0), 0b10);
+        assert_eq!(bitops_u8::toggle_bit(u8::MAX, 7), u8::MAX / 2);
 
-        assert!(bitops_u64::is_set(bitops_u64::toggle(0, 0), 0));
-        assert!(!bitops_u64::is_set(bitops_u64::toggle(1, 0), 0));
-        assert_eq!(bitops_u64::toggle(3, 0), 0b10);
-        assert_eq!(bitops_u64::toggle(u64::MAX, 63), u64::MAX / 2);
+        assert!(bitops_u64::is_set(bitops_u64::toggle_bit(0, 0), 0));
+        assert!(!bitops_u64::is_set(bitops_u64::toggle_bit(1, 0), 0));
+        assert_eq!(bitops_u64::toggle_bit(3, 0), 0b10);
+        assert_eq!(bitops_u64::toggle_bit(u64::MAX, 63), u64::MAX / 2);
+    }
+
+    #[test]
+    fn toggle_bits() {
+        assert_eq!(bitops_u8::toggle_bits(0, 0, 0), 0);
+        assert_eq!(bitops_u8::toggle_bits(1, 0, 0), 1);
+        assert_eq!(bitops_u8::toggle_bits(0b111, 2, 1), 1);
+        assert_eq!(bitops_u8::toggle_bits(0, 2, 1), 0b110);
+
+        assert_eq!(bitops_u64::toggle_bits(0, 0, 0), 0);
+        assert_eq!(bitops_u64::toggle_bits(1, 0, 0), 1);
+        assert_eq!(bitops_u64::toggle_bits(0b111, 2, 1), 1);
+        assert_eq!(bitops_u64::toggle_bits(u64::MAX, 62, 2), 0b11);
     }
 
     #[test]
@@ -217,16 +230,6 @@ mod tests {
 
         assert_eq!(bitops_u64::create_mask(0), 0);
         assert_eq!(bitops_u64::create_mask(64), u64::MAX);
-    }
-
-    #[test]
-    fn create_mask_shifted() {
-        assert_eq!(bitops_u8::create_shifted_mask(0, 5), 0);
-        assert_eq!(bitops_u8::create_shifted_mask(1, 5), 0b10_0000);
-        assert_eq!(bitops_u8::create_shifted_mask(2, 5), 0b110_0000);
-        assert_eq!(bitops_u8::create_shifted_mask(3, 5), 0b1110_0000);
-
-        assert_eq!(bitops_u64::create_shifted_mask(1, 63), u64::MAX / 2 + 1);
     }
 
     /// This tests various functions in combination using a real-world scenario.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,10 +39,12 @@ SOFTWARE.
 //! next months in Rust stable. `bit_ops` will adapt, as soon as this
 //! changes.
 //!
-//! Note that the most trivial operations, such as `"shift_bits"` or
-//! `"keep_bits"` won't be covered by the API, as they would be a convoluted way
-//! around the standard operators `<<`, `>>`, and `&`. Only non-trivial
-//! non-oneliners are covered by the API.
+//! Note that the most trivial bit operations, such as `"shift_bits"` or
+//! `"keep_bits"` won't be covered by the API, as this would introduce a
+//! convoluted way around the standard operators `<<`, `>>`, and `&`. Only
+//! non-trivial non-oneliners are covered by the API as well as operations,
+//! where the semantic name provides a value-add over a (possible even oneliner)
+//! (combination of) bit operation.
 //!
 //! ### Function API
 //!
@@ -117,6 +119,14 @@ SOFTWARE.
 //! let raw = 0_u64.set_bit(1).set_bit(2);
 //! assert_eq!(raw, 0b110);
 //! ```
+//!
+//! ## MSRV
+//!
+//! 1.57.0 stable
+//!
+//! ## License
+//!
+//! MIT License.
 
 #![deny(
     clippy::all,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,13 @@ SOFTWARE.
 //! the foundation and provides `no_std` and `const`-compatible functions. The
 //! Trait API won't be `const`-compatible unless `const` trait methods are
 //! supported by Rust (stable). This is not the case in Mid-2024 and the
-//! next months in Rust stable. This crate will adapt, as soon as this
+//! next months in Rust stable. `bit_ops` will adapt, as soon as this
 //! changes.
+//!
+//! Note that the most trivial operations, such as `"shift_bits"` or
+//! `"keep_bits"` won't be covered by the API, as they would be a convoluted way
+//! around the standard operators `<<`, `>>`, and `&`. Only non-trivial
+//! non-oneliners are covered by the API.
 //!
 //! ### Function API
 //!

--- a/src/trait_api/macros.rs
+++ b/src/trait_api/macros.rs
@@ -74,15 +74,27 @@ macro_rules! impl_trait {
                 }
             }
 
-            #[doc = concat!("Wrapper around [`bitops_", stringify!($primitive_ty), "::toggle`],")]
+            #[doc = concat!("Wrapper around [`bitops_", stringify!($primitive_ty), "::toggle_bit`],")]
             #[doc = concat!("but as associated function (method) on `", stringify!($primitive_ty), "`.")]
             #[doc = ""] // newline needed so that markdown links work
-            #[doc = concat!("[`bitops_", stringify!($primitive_ty), "::toggle`]: crate::bitops_", stringify!($primitive_ty), "::toggle")]
+            #[doc = concat!("[`bitops_", stringify!($primitive_ty), "::toggle_bit`]: crate::bitops_", stringify!($primitive_ty), "::toggle_bit")]
             #[inline]
             #[must_use]
-            fn toggle(self, bit: Self) -> Self {
+            fn toggle_bit(self, bit: Self) -> Self {
                 paste::paste! {
-                    $crate::[< bitops _ $primitive_ty >]::toggle(self, bit)
+                    $crate::[< bitops _ $primitive_ty >]::toggle_bit(self, bit)
+                }
+            }
+
+            #[doc = concat!("Wrapper around [`bitops_", stringify!($primitive_ty), "::toggle_bits`],")]
+            #[doc = concat!("but as associated function (method) on `", stringify!($primitive_ty), "`.")]
+            #[doc = ""] // newline needed so that markdown links work
+            #[doc = concat!("[`bitops_", stringify!($primitive_ty), "::toggle_bits`]: crate::bitops_", stringify!($primitive_ty), "::toggle_bits")]
+            #[inline]
+            #[must_use]
+            fn toggle_bits(self, bits: Self, shift: Self) -> Self {
+                paste::paste! {
+                    $crate::[< bitops _ $primitive_ty >]::toggle_bits(self, bits, shift)
                 }
             }
 
@@ -191,18 +203,6 @@ macro_rules! impl_trait {
             fn create_mask(bits: Self) -> Self {
                 paste::paste! {
                     $crate::[< bitops _ $primitive_ty >]::create_mask(bits)
-                }
-            }
-
-            #[doc = concat!("Wrapper around [`bitops_", stringify!($primitive_ty), "::create_shifted_mask`],")]
-            #[doc = concat!("but as associated function (method) on `", stringify!($primitive_ty), "`.")]
-            #[doc = ""] // newline needed so that markdown links work
-            #[doc = concat!("[`bitops_", stringify!($primitive_ty), "::create_shifted_mask`]: crate::bitops_", stringify!($primitive_ty), "::create_shifted_mask")]
-            #[inline]
-            #[must_use]
-            fn create_shifted_mask(bits: Self, lshift: Self) -> Self {
-                paste::paste! {
-                    $crate::[< bitops _ $primitive_ty >]::create_shifted_mask(bits, lshift)
                 }
             }
         }

--- a/src/trait_api/mod.rs
+++ b/src/trait_api/mod.rs
@@ -54,7 +54,17 @@ pub trait BitOps: Copy + Sized {
     ///
     /// The bit position starts at `0`.
     #[must_use]
-    fn toggle(self, bit: Self) -> Self;
+    fn toggle_bit(self, bit: Self) -> Self;
+
+    /// Toggles (flips) the specified contiguous bits.
+    ///
+    /// # Parameters
+    ///
+    /// - `value`: Base value to alter.
+    /// - `bits`: Amount of bits of `value` that are relevant, starting from the right.
+    /// - `shift`: Relevant position of bits inside `value`, starting from the right.
+    #[must_use]
+    fn toggle_bits(self, bits: Self, shift: Self) -> Self;
 
     /// Sets the bits of `value` in `base` without clearing already set bits.
     ///
@@ -114,7 +124,7 @@ pub trait BitOps: Copy + Sized {
     #[must_use]
     fn lowest_bit(self) -> Option<Self>;
 
-    /// Get the requested bits as new integer.
+    /// Get the requested contiguous bits as new integer.
     ///
     /// # Parameters
     ///
@@ -124,13 +134,9 @@ pub trait BitOps: Copy + Sized {
     #[must_use]
     fn get_bits(self, value_bits: Self, value_shift: Self) -> Self;
 
-    /// Creates a bitmask (`1`s) with the given amount of bits.
+    /// Creates a bitmask (`1`s) with the given amount of contiguous bits .
     #[must_use]
     fn create_mask(bits: Self) -> Self;
-
-    /// Like [`Self::create_mask`] but shifts the mask.
-    #[must_use]
-    fn create_shifted_mask(bits: Self, lshift: Self) -> Self;
 }
 
 impl_trait!(u8);

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -20,7 +20,8 @@ fn const_compatible() {
         let _ = set_bit(0, 0);
         let _ = clear_bit(0, 0);
         let _ = is_set(0, 0);
-        let _ = toggle(0, 0);
+        let _ = toggle_bit(0, 0);
+        let _ = toggle_bits(0, 0, 0);
         let _ = set_bits(0, 0, 0, 0);
         // let _ = set_bits_n(0, &[]);
         let _ = set_bits_exact(0, 0, 0, 0);
@@ -30,7 +31,6 @@ fn const_compatible() {
         let _ = lowest_bit(0);
         let _ = get_bits(0, 0, 0);
         let _ = create_mask(0);
-        let _ = create_shifted_mask(0, 0);
     }
     compiles();
 }


### PR DESCRIPTION

- Removed `create_shifted_mask` as `create_mask() << 5` is a trivial replacement
- Renamed `toggle` to `toggle_bit`
- Added `toggle_bits`