### PR TITLE
api: `set_bits_n` and `set_bits_exact_n` are now `const`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
 
-# v0.1.9, v0.1.10  - 2024-07-30
+# v0.1.11 - 2024-07-30
+
+- Functions `set_bits_n` and `set_bits_exact_n` are now `const` compatible
+
+# v0.1.9, v0.1.10 - 2024-07-30
 
 - Removed `create_shifted_mask` as `create_mask() << 5` is a trivial replacement
 - Renamed `toggle` to `toggle_bit`

--- a/src/function_api/macros.rs
+++ b/src/function_api/macros.rs
@@ -252,9 +252,6 @@ macro_rules! impl_bit_ops {
         /// Version of [`set_bits`] that applies a list of multiple values to
         /// the base.
         ///
-        /// This function, unlike the others, is not `const` yet due to the
-        /// inner loop.
-        ///
         /// # Parameters
         ///
         /// - `base`: Base value to set bits in.
@@ -289,8 +286,7 @@ macro_rules! impl_bit_ops {
         /// are outside the range of the underlying type.
         #[must_use]
         #[inline]
-        // TODO make const as soon as for-loops can be in const fn
-        pub fn set_bits_n(
+        pub const fn set_bits_n(
             base: $primitive_ty,
             ops: &[(
                 $primitive_ty, /* value */
@@ -299,8 +295,11 @@ macro_rules! impl_bit_ops {
             )],
         ) -> $primitive_ty {
             let mut base = base;
-            for op in ops {
+            let mut i = 0;
+            while i < ops.len() {
+                let op = ops[i];
                 base = set_bits(base, op.0, op.1, op.2);
+                i += 1;
             }
             base
         }
@@ -321,13 +320,9 @@ macro_rules! impl_bit_ops {
         }
 
         /// Combination of [`set_bits_exact`] and [`set_bits_n`].
-        ///
-        /// This function, unlike the others, is not `const` yet due to the
-        /// inner loop.
         #[must_use]
         #[inline]
-        // TODO make const as soon as for-loops can be in const fn
-        pub fn set_bits_exact_n(
+        pub const fn set_bits_exact_n(
             base: $primitive_ty,
             ops: &[(
                 $primitive_ty, /* value */
@@ -336,8 +331,11 @@ macro_rules! impl_bit_ops {
             )],
         ) -> $primitive_ty {
             let mut base = base;
-            for op in ops {
+            let mut i = 0;
+            while i < ops.len() {
+                let op = ops[i];
                 base = set_bits_exact(base, op.0, op.1, op.2);
+                i += 1;
             }
             base
         }

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -23,9 +23,9 @@ fn const_compatible() {
         let _ = toggle_bit(0, 0);
         let _ = toggle_bits(0, 0, 0);
         let _ = set_bits(0, 0, 0, 0);
-        // let _ = set_bits_n(0, &[]);
+        let _ = set_bits_n(0, &[]);
         let _ = set_bits_exact(0, 0, 0, 0);
-        // let _ = set_bits_exact_n(0, &[]);
+        let _ = set_bits_exact_n(0, &[]);
         let _ = clear_bits(0, 0);
         let _ = highest_bit(0);
         let _ = lowest_bit(0);


### PR DESCRIPTION
Turns out that while loops are supported in `const` contexts.