### PR TITLE
Add no_std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,8 @@ repository = "https://github.com/phip1611/bit_ops"
 documentation = "https://docs.rs/bit_ops"
 rust-version = "1.57" # MSRV
 
+[features]
+no_std = []
+
 [dependencies]
 paste = "1.0.15"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,8 @@ SOFTWARE.
 #![deny(missing_debug_implementations)]
 #![deny(rustdoc::all)]
 
+#![cfg_attr(feature = "no_std", no_std)]
+
 mod function_api;
 mod trait_api;
 


### PR DESCRIPTION
When compiling for `no_std`  with `rustc 1.80.0 (051478957 2024-07-21)` on `thumbv7em-none-eabihf` the following errors are observed:
```
   3   │    Compiling bit_ops v0.1.11
   4   │ error[E0463]: can't find crate for `std`
   5   │   |
   6   │   = note: the `thumbv7em-none-eabihf` target may not support the standard library
   7   │   = note: `std` is required by `bit_ops` because it does not declare `#![no_std]`
   8   │
   9   │ error: cannot find macro `concat` in this scope
  10   │   --> /home/jkelley/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bit_ops-0.1.11/src/function_api/macros.rs:55:17
  11   │    |
  12   │ 55 |         #[doc = concat!("use bit_ops::bitops_", stringify!($primitive_ty), "::set_bit;")]
  13   │    |                 ^^^^^^
  14   │    |
  15   │   ::: /home/jkelley/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bit_ops-0.1.11/src/function_api/mod.rs:43:1
  16   │    |
  17   │ 43 | impl_mod!(u8);
  18   │    | ------------- in this macro invocation
  19   │    |
  20   │    = help: consider importing this macro:
  21   │            core::concat
  22   │    = note: this error originates in the macro `impl_bit_ops` which comes from the expansion of the macro `impl_mod` (in Nightly builds, ru
       │ n with -Z macro-backtrace for more info)
```

Adding a `no_std` feature and having `lib.rs` declare `no_std` when it is enabled fixes the errors observed above.