### PR TITLE
set_bit_to function to set particular bit to a given value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea

--- a/src/function_api/macros.rs
+++ b/src/function_api/macros.rs
@@ -73,6 +73,45 @@ macro_rules! impl_bit_ops {
             base | (1 << bit)
         }
 
+        /// Sets the given bit to the given value.
+        ///
+        /// The bit position starts at `0`.
+        ///
+        /// # Parameters
+        ///
+        /// - `base`: Base value to alter.
+        /// - `bit`: Bit to set, starting at position `0`.
+        /// - `value`: Value to set.
+        /// # Example
+        ///
+        /// ```rust
+        #[doc = concat!("use bit_ops::bitops_", stringify!($primitive_ty), "::set_bit_to;")]
+        ///
+        /// let raw = set_bit_to(0, 7, true);
+        /// assert_eq!(raw, 0b1000_0000);
+        ///
+        /// let raw = set_bit_to(0b1000_0000, 7, false);
+        /// assert_eq!(raw, 0b0000_0000);
+        ///
+        /// ```
+        ///
+        /// # Panics
+        /// This function panics for bit positions that are outside the range of
+        /// the underlying type.
+        #[must_use]
+        #[inline]
+        pub const fn set_bit_to(
+            base: $primitive_ty,
+            bit: $primitive_ty,
+            value: bool,
+        ) -> $primitive_ty {
+            if value {
+                set_bit(base, bit)
+            } else {
+                clear_bit(base, bit)
+            }
+        }
+
         /// Clears the given bit by setting it to `0`.
         ///
         /// The bit position starts at `0`.

--- a/src/function_api/macros.rs
+++ b/src/function_api/macros.rs
@@ -85,12 +85,12 @@ macro_rules! impl_bit_ops {
         /// # Example
         ///
         /// ```rust
-        #[doc = concat!("use bit_ops::bitops_", stringify!($primitive_ty), "::set_bit_to;")]
+        #[doc = concat!("use bit_ops::bitops_", stringify!($primitive_ty), "::set_bit_exact;")]
         ///
-        /// let raw = set_bit_to(0, 7, true);
+        /// let raw = set_bit_exact(0, 7, true);
         /// assert_eq!(raw, 0b1000_0000);
         ///
-        /// let raw = set_bit_to(0b1000_0000, 7, false);
+        /// let raw = set_bit_exact(0b1000_0000, 7, false);
         /// assert_eq!(raw, 0b0000_0000);
         ///
         /// ```
@@ -100,7 +100,7 @@ macro_rules! impl_bit_ops {
         /// the underlying type.
         #[must_use]
         #[inline]
-        pub const fn set_bit_to(
+        pub const fn set_bit_exact(
             base: $primitive_ty,
             bit: $primitive_ty,
             value: bool,

--- a/src/function_api/mod.rs
+++ b/src/function_api/mod.rs
@@ -67,18 +67,18 @@ mod tests {
     }
 
     #[test]
-    fn set_bit_to() {
-        assert_eq!(bitops_u8::set_bit_to(0, 0, true), 1);
-        assert_eq!(bitops_u8::set_bit_to(0, 0, false), 0);
-        assert_eq!(bitops_u8::set_bit_to(1, 1, true), 3);
-        assert_eq!(bitops_u8::set_bit_to(1, 0, true), 1);
-        assert_eq!(bitops_u8::set_bit_to(1, 0, false), 0);
+    fn set_bit_exact() {
+        assert_eq!(bitops_u8::set_bit_exact(0, 0, true), 1);
+        assert_eq!(bitops_u8::set_bit_exact(0, 0, false), 0);
+        assert_eq!(bitops_u8::set_bit_exact(1, 1, true), 3);
+        assert_eq!(bitops_u8::set_bit_exact(1, 0, true), 1);
+        assert_eq!(bitops_u8::set_bit_exact(1, 0, false), 0);
 
-        assert_eq!(bitops_u64::set_bit_to(0, 0, true), 1);
-        assert_eq!(bitops_u64::set_bit_to(0, 0, false), 0);
-        assert_eq!(bitops_u64::set_bit_to(1, 1, true), 3);
-        assert_eq!(bitops_u64::set_bit_to(1, 0, true), 1);
-        assert_eq!(bitops_u64::set_bit_to(1, 0, false), 0);
+        assert_eq!(bitops_u64::set_bit_exact(0, 0, true), 1);
+        assert_eq!(bitops_u64::set_bit_exact(0, 0, false), 0);
+        assert_eq!(bitops_u64::set_bit_exact(1, 1, true), 3);
+        assert_eq!(bitops_u64::set_bit_exact(1, 0, true), 1);
+        assert_eq!(bitops_u64::set_bit_exact(1, 0, false), 0);
     }
 
     #[test]

--- a/src/function_api/mod.rs
+++ b/src/function_api/mod.rs
@@ -67,6 +67,21 @@ mod tests {
     }
 
     #[test]
+    fn set_bit_to() {
+        assert_eq!(bitops_u8::set_bit_to(0, 0, true), 1);
+        assert_eq!(bitops_u8::set_bit_to(0, 0, false), 0);
+        assert_eq!(bitops_u8::set_bit_to(1, 1, true), 3);
+        assert_eq!(bitops_u8::set_bit_to(1, 0, true), 1);
+        assert_eq!(bitops_u8::set_bit_to(1, 0, false), 0);
+
+        assert_eq!(bitops_u64::set_bit_to(0, 0, true), 1);
+        assert_eq!(bitops_u64::set_bit_to(0, 0, false), 0);
+        assert_eq!(bitops_u64::set_bit_to(1, 1, true), 3);
+        assert_eq!(bitops_u64::set_bit_to(1, 0, true), 1);
+        assert_eq!(bitops_u64::set_bit_to(1, 0, false), 0);
+    }
+
+    #[test]
     fn clear_bit() {
         assert_eq!(bitops_u8::clear_bit(1, 0), 0);
         assert_eq!(bitops_u8::clear_bit(3, 1), 1);

--- a/src/trait_api/macros.rs
+++ b/src/trait_api/macros.rs
@@ -37,14 +37,14 @@ macro_rules! impl_trait {
                 }
             }
 
-            #[doc = concat!("Wrapper around [`bitops_", stringify!($primitive_ty), "::set_bit_to`],")]
+            #[doc = concat!("Wrapper around [`bitops_", stringify!($primitive_ty), "::set_bit_exact`],")]
             #[doc = concat!("but as associated function (method) on `", stringify!($primitive_ty), "`.")]
             #[doc = ""] // newline needed so that markdown links work
-            #[doc = concat!("[`bitops_", stringify!($primitive_ty), "::set_bit_to`]: crate::bitops_", stringify!($primitive_ty), "::set_bit_to")]
+            #[doc = concat!("[`bitops_", stringify!($primitive_ty), "::set_bit_exact`]: crate::bitops_", stringify!($primitive_ty), "::set_bit_exact")]
             #[inline]
-            fn set_bit_to(self, bit: Self, value: bool) -> Self {
+            fn set_bit_exact(self, bit: Self, value: bool) -> Self {
                 paste::paste! {
-                    $crate::[< bitops _ $primitive_ty >]::set_bit_to(self, bit, value)
+                    $crate::[< bitops _ $primitive_ty >]::set_bit_exact(self, bit, value)
                 }
             }
 

--- a/src/trait_api/macros.rs
+++ b/src/trait_api/macros.rs
@@ -37,6 +37,17 @@ macro_rules! impl_trait {
                 }
             }
 
+            #[doc = concat!("Wrapper around [`bitops_", stringify!($primitive_ty), "::set_bit_to`],")]
+            #[doc = concat!("but as associated function (method) on `", stringify!($primitive_ty), "`.")]
+            #[doc = ""] // newline needed so that markdown links work
+            #[doc = concat!("[`bitops_", stringify!($primitive_ty), "::set_bit_to`]: crate::bitops_", stringify!($primitive_ty), "::set_bit_to")]
+            #[inline]
+            fn set_bit_to(self, bit: Self, value: bool) -> Self {
+                paste::paste! {
+                    $crate::[< bitops _ $primitive_ty >]::set_bit_to(self, bit, value)
+                }
+            }
+
             #[doc = concat!("Wrapper around [`bitops_", stringify!($primitive_ty), "::clear_bit`],")]
             #[doc = concat!("but as associated function (method) on `", stringify!($primitive_ty), "`.")]
             #[doc = ""] // newline needed so that markdown links work

--- a/src/trait_api/mod.rs
+++ b/src/trait_api/mod.rs
@@ -45,7 +45,7 @@ pub trait BitOps: Copy + Sized {
     /// - `bit`: Bit to set, starting at position `0`.
     /// - `value`: Value to set.
     #[must_use]
-    fn set_bit_to(self, bit: Self, value: bool) -> Self;
+    fn set_bit_exact(self, bit: Self, value: bool) -> Self;
 
     /// Clears the given bit by setting it to `0`.
     ///

--- a/src/trait_api/mod.rs
+++ b/src/trait_api/mod.rs
@@ -36,6 +36,17 @@ pub trait BitOps: Copy + Sized {
     #[must_use]
     fn set_bit(self, bit: Self) -> Self;
 
+    /// Sets the given bit to the given value.
+    ///
+    /// The bit position starts at `0`.
+    ///
+    /// # Parameters
+    ///
+    /// - `bit`: Bit to set, starting at position `0`.
+    /// - `value`: Value to set.
+    #[must_use]
+    fn set_bit_to(self, bit: Self, value: bool) -> Self;
+
     /// Clears the given bit by setting it to `0`.
     ///
     /// The bit position starts at `0`.

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -18,6 +18,7 @@ fn const_compatible() {
     const fn compiles() {
         use bitops_u64::*;
         let _ = set_bit(0, 0);
+        let _ = set_bit_to(0, 0, false);
         let _ = clear_bit(0, 0);
         let _ = is_set(0, 0);
         let _ = toggle_bit(0, 0);
@@ -47,4 +48,10 @@ fn test_public_trait_api() {
 
     let raw = 0_u64.set_bit(0).set_bit(1).set_bit(4);
     assert_eq!(raw, 0b10011);
+
+    let raw = 0b10101010_u8
+        .set_bit_to(0, true)
+        .set_bit_to(1, false)
+        .set_bit_to(7, false);
+    assert_eq!(raw, 0b00101001);
 }

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -18,7 +18,7 @@ fn const_compatible() {
     const fn compiles() {
         use bitops_u64::*;
         let _ = set_bit(0, 0);
-        let _ = set_bit_to(0, 0, false);
+        let _ = set_bit_exact(0, 0, false);
         let _ = clear_bit(0, 0);
         let _ = is_set(0, 0);
         let _ = toggle_bit(0, 0);
@@ -50,8 +50,8 @@ fn test_public_trait_api() {
     assert_eq!(raw, 0b10011);
 
     let raw = 0b10101010_u8
-        .set_bit_to(0, true)
-        .set_bit_to(1, false)
-        .set_bit_to(7, false);
+        .set_bit_exact(0, true)
+        .set_bit_exact(1, false)
+        .set_bit_exact(7, false);
     assert_eq!(raw, 0b00101001);
 }


### PR DESCRIPTION
I didn't find a way to set a bit to some external value and currently you forced to write it like this:

``` rust
if value {
    flags.set_bit(bit)
} else {
    flags.clear_bit(bit)
}
```

I want it to be a bit more convenient so I implemented `set_bit_to` function and now I will be able to write it like this:
```rust
flags.set_bit_to(bit, value);
```
